### PR TITLE
refactor CLI, enhance document editing, add prompt metadata

### DIFF
--- a/src/ai/prompts.py
+++ b/src/ai/prompts.py
@@ -44,6 +44,8 @@ def build_sectionizer_prompt(resume_with_line_numbers: str) -> str:
 # build generate prompt for LLM
 def build_generate_prompt(job_info: str,
                          resume_with_line_numbers: str,
+                         model: str,
+                         created_at: str,
                          sections_json: str | None = None) -> str:
     return (
         "You are a resume editor tasked with tailoring a resume (provided as numbered lines) "
@@ -83,7 +85,7 @@ def build_generate_prompt(job_info: str,
         "Output ONLY JSON matching this schema exactly:\n"
         "{\n"
         "  \"version\": 1,\n"
-        "  \"meta\": { \"strategy\": \"rule\", \"model\": \"<model_name>\", \"created_at\": \"<ISO8601_timestamp>\" },\n"
+        f"  \"meta\": {{ \"strategy\": \"rule\", \"model\": \"{model}\", \"created_at\": \"{created_at}\" }},\n"
         "  \"ops\": [\n"
         "    { \"op\": \"replace_line\", \"line\": <int>, \"text\": \"string\", \"current_snippet\": \"string\", \"why\": \"string (optional)\" },\n"
         "    { \"op\": \"replace_range\", \"start\": <int>, \"end\": <int>, \"text\": \"string\", \"current_snippet\": \"string\", \"why\": \"string (optional)\" },\n"
@@ -93,7 +95,7 @@ def build_generate_prompt(job_info: str,
         "}\n\n"
 
         "Requirements:\n"
-        "- Include version: 1 and meta object with strategy, model, and ISO8601 timestamp\n"
+        f"- Include version: 1 and meta object with strategy, model ({model}), and timestamp ({created_at})\n"
         "- For 'current_snippet': Include the EXACT current text being modified (for validation)\n"
         "- For 'why' field (optional): Name the job phrase this targets and why it improves alignment\n"
         "- For replace_range: 'text' should be multi-line content (use \\n for line breaks)\n"
@@ -112,6 +114,8 @@ def build_edit_prompt(job_info: str,
                      resume_with_line_numbers: str, 
                      edits_json: str,
                      validation_errors: list[str],
+                     model: str,
+                     created_at: str,
                      sections_json: str | None = None) -> str:
     return (
         "You are a resume editor tasked with FIXING VALIDATION ERRORS in a previously generated "
@@ -142,7 +146,7 @@ def build_edit_prompt(job_info: str,
         "Output ONLY the corrected JSON matching this schema exactly:\n"
         "{\n"
         "  \"version\": 1,\n"
-        "  \"meta\": { \"strategy\": \"edit_fix\", \"model\": \"<model_name>\", \"created_at\": \"<ISO8601_timestamp>\" },\n"
+        f"  \"meta\": {{ \"strategy\": \"edit_fix\", \"model\": \"{model}\", \"created_at\": \"{created_at}\" }},\n"
         "  \"ops\": [\n"
         "    { \"op\": \"replace_line\", \"line\": <int>, \"text\": \"string\", \"current_snippet\": \"string\", \"why\": \"string (optional)\" },\n"
         "    { \"op\": \"replace_range\", \"start\": <int>, \"end\": <int>, \"text\": \"string\", \"current_snippet\": \"string\", \"why\": \"string (optional)\" },\n"
@@ -162,4 +166,5 @@ def build_edit_prompt(job_info: str,
         "INVALID Edits JSON (to be corrected):\n"
         f"{edits_json}\n"
     )
+
 

--- a/src/ai/prompts.py
+++ b/src/ai/prompts.py
@@ -73,26 +73,28 @@ def build_generate_prompt(job_info: str,
 
         "Line-numbering rules:\n"
         "1) Use the exact 1-based line numbers provided.\n"
-        "2) For tiny tweaks, use 'replace_line'. For multi-line rewrites, use 'replace_range' only if necessary.\n"
-        "3) To add a new bullet directly after a line, use 'insert_after' (only to split existing substance for clarity or to surface job-relevant detail already present elsewhere in the resume).\n"
-        "4) To remove irrelevant content, use 'delete_range' and explain why it hurts alignment.\n"
-        "5) Never output lines that don't exist; validate with 'current_snippet' to avoid drift.\n"
-        "6) Keep proper tech casing (TypeScript, JavaScript, PostgreSQL) and only correct if wrong.\n\n"
+        "2) CRITICAL: For 'replace_line', the text must be a SINGLE line with NO newline characters. If you need multiple lines, use 'replace_range' instead.\n"
+        "3) For tiny tweaks, use 'replace_line'. For multi-line rewrites, use 'replace_range'.\n"
+        "4) To add a new bullet directly after a line, use 'insert_after' (only to split existing substance for clarity or to surface job-relevant detail already present elsewhere in the resume).\n"
+        "5) To remove irrelevant content, use 'delete_range' and explain why it hurts alignment.\n"
+        "6) Never output lines that don't exist; validate with 'current_snippet' to avoid drift.\n"
+        "7) Keep proper tech casing (TypeScript, JavaScript, PostgreSQL) and only correct if wrong.\n\n"
 
         "Output ONLY JSON matching this schema exactly:\n"
         "{\n"
         "  \"version\": 1,\n"
         "  \"meta\": { \"strategy\": \"rule\", \"model\": \"<model_name>\", \"created_at\": \"<ISO8601_timestamp>\" },\n"
         "  \"ops\": [\n"
-        "    { \"op\": \"replace_line\", \"line\": <int>, \"text\": \"string\", \"why\": \"string (optional)\" },\n"
-        "    { \"op\": \"replace_range\", \"start\": <int>, \"end\": <int>, \"text\": \"string\", \"why\": \"string (optional)\" },\n"
-        "    { \"op\": \"insert_after\", \"line\": <int>, \"text\": \"string\", \"why\": \"string (optional)\" },\n"
-        "    { \"op\": \"delete_range\", \"start\": <int>, \"end\": <int>, \"why\": \"string (optional)\" }\n"
+        "    { \"op\": \"replace_line\", \"line\": <int>, \"text\": \"string\", \"current_snippet\": \"string\", \"why\": \"string (optional)\" },\n"
+        "    { \"op\": \"replace_range\", \"start\": <int>, \"end\": <int>, \"text\": \"string\", \"current_snippet\": \"string\", \"why\": \"string (optional)\" },\n"
+        "    { \"op\": \"insert_after\", \"line\": <int>, \"text\": \"string\", \"current_snippet\": \"string\", \"why\": \"string (optional)\" },\n"
+        "    { \"op\": \"delete_range\", \"start\": <int>, \"end\": <int>, \"current_snippet\": \"string\", \"why\": \"string (optional)\" }\n"
         "  ]\n"
         "}\n\n"
 
         "Requirements:\n"
         "- Include version: 1 and meta object with strategy, model, and ISO8601 timestamp\n"
+        "- For 'current_snippet': Include the EXACT current text being modified (for validation)\n"
         "- For 'why' field (optional): Name the job phrase this targets and why it improves alignment\n"
         "- For replace_range: 'text' should be multi-line content (use \\n for line breaks)\n"
         "- For insert_after: 'text' should be the content to insert (use \\n for multiple lines)\n"
@@ -103,5 +105,61 @@ def build_generate_prompt(job_info: str,
         + (f"Known Sections (JSON):\n{sections_json}\n\n" if sections_json else "") +
         "Resume (numbered lines start at 1):\n"
         f"{resume_with_line_numbers}\n"
+    )
+
+# build edit prompt for fixing validation errors in edits.json
+def build_edit_prompt(job_info: str,
+                     resume_with_line_numbers: str, 
+                     edits_json: str,
+                     validation_errors: list[str],
+                     sections_json: str | None = None) -> str:
+    return (
+        "You are a resume editor tasked with FIXING VALIDATION ERRORS in a previously generated "
+        "edits JSON file. The edits were created to tailor a resume to a job description, but "
+        "contain validation errors that prevent them from being applied.\n\n"
+
+        "Your task is to CORRECT the existing edits to fix validation errors while preserving "
+        "the original intent and improving job alignment. Do NOT generate entirely new edits.\n\n"
+
+        "Common validation errors to fix:\n"
+        "- 'replace_line text contains newline; use replace_range': Convert replace_line ops with "
+        "  newlines to replace_range ops with proper start/end line numbers\n"
+        "- 'line X not in resume bounds': Remove ops referencing non-existent lines\n"
+        "- 'duplicate operation on line X': Remove or merge conflicting ops on same line\n"
+        "- 'replace_range line count mismatch': Adjust text to match the range size or vice versa\n"
+        "- Missing required fields: Add any missing 'op', 'line', 'text', 'start', 'end' fields\n"
+        "- Invalid ranges: Fix start > end or negative line numbers\n\n"
+
+        "Correction rules:\n"
+        "1. FIX errors without changing the editing intent - preserve the original meaning\n"
+        "2. For replace_line with newlines: Convert to replace_range with proper line boundaries\n"
+        "3. For out-of-bounds lines: Either remove the op or adjust to valid line numbers\n"
+        "4. For duplicate ops: Keep the most comprehensive edit or merge if possible\n"
+        "5. For line count mismatches: Adjust the range to match the intended text length\n"
+        "6. Maintain the same job-alignment improvements as the original edits\n"
+        "7. Keep all valid operations unchanged\n\n"
+
+        "Output ONLY the corrected JSON matching this schema exactly:\n"
+        "{\n"
+        "  \"version\": 1,\n"
+        "  \"meta\": { \"strategy\": \"edit_fix\", \"model\": \"<model_name>\", \"created_at\": \"<ISO8601_timestamp>\" },\n"
+        "  \"ops\": [\n"
+        "    { \"op\": \"replace_line\", \"line\": <int>, \"text\": \"string\", \"current_snippet\": \"string\", \"why\": \"string (optional)\" },\n"
+        "    { \"op\": \"replace_range\", \"start\": <int>, \"end\": <int>, \"text\": \"string\", \"current_snippet\": \"string\", \"why\": \"string (optional)\" },\n"
+        "    { \"op\": \"insert_after\", \"line\": <int>, \"text\": \"string\", \"current_snippet\": \"string\", \"why\": \"string (optional)\" },\n"
+        "    { \"op\": \"delete_range\", \"start\": <int>, \"end\": <int>, \"current_snippet\": \"string\", \"why\": \"string (optional)\" }\n"
+        "  ]\n"
+        "}\n\n"
+
+        "Validation Errors Found:\n"
+        + "\n".join(f"- {error}" for error in validation_errors) + "\n\n"
+
+        "Job Description:\n"
+        f"{job_info}\n\n"
+        + (f"Known Sections (JSON):\n{sections_json}\n\n" if sections_json else "") +
+        "Resume (numbered lines start at 1):\n"
+        f"{resume_with_line_numbers}\n\n"
+        "INVALID Edits JSON (to be corrected):\n"
+        f"{edits_json}\n"
     )
 

--- a/src/cli/args.py
+++ b/src/cli/args.py
@@ -12,12 +12,12 @@ SETTINGS = settings_manager.load()
 
 ResumeArg = Annotated[
     Path,
-    typer.Argument(..., help="Path to resume .docx", exists=True, file_okay=True, dir_okay=False, readable=True, resolve_path=True),
+    typer.Argument(help="Path to resume .docx", exists=True, file_okay=True, dir_okay=False, readable=True, resolve_path=True),
 ]
 
 JobArg = Annotated[
     Path,
-    typer.Argument(..., help="Path to job description", exists=True, file_okay=True, dir_okay=False, readable=True, resolve_path=True),
+    typer.Argument(help="Path to job description", exists=True, file_okay=True, dir_okay=False, readable=True, resolve_path=True),
 ]
 
 ModelOpt = Annotated[

--- a/src/cli/args.py
+++ b/src/cli/args.py
@@ -5,6 +5,11 @@ from pathlib import Path
 from typing import Annotated, Optional
 import typer
 
+from ..config.settings import settings_manager
+
+# load settings once
+SETTINGS = settings_manager.load()
+
 ResumeArg = Annotated[
     Path,
     typer.Argument(..., help="Path to resume .docx", exists=True, file_okay=True, dir_okay=False, readable=True, resolve_path=True),

--- a/src/core/pipeline.py
+++ b/src/core/pipeline.py
@@ -7,6 +7,7 @@ import difflib
 import sys
 import json
 from pathlib import Path
+from datetime import datetime, timezone
 from ..config.settings import settings_manager
 
 # load settings once
@@ -129,7 +130,8 @@ def generate_edits(resume_lines: Lines, job_text: str, sections_json: str | None
     
     def create_edits():
         nonlocal edits
-        prompt = build_generate_prompt(job_text, number_lines(resume_lines), sections_json)
+        created_at = datetime.now(timezone.utc).isoformat()
+        prompt = build_generate_prompt(job_text, number_lines(resume_lines), model, created_at, sections_json)
         edits = run_generate(prompt, model)
         
         # validate response structure
@@ -152,7 +154,8 @@ def generate_edits(resume_lines: Lines, job_text: str, sections_json: str | None
             raise ValueError("No existing edits file found for correction")
         
         from ..ai.prompts import build_edit_prompt
-        prompt = build_edit_prompt(job_text, number_lines(resume_lines), current_edits_json, validation_warnings, sections_json)
+        created_at = datetime.now(timezone.utc).isoformat()
+        prompt = build_edit_prompt(job_text, number_lines(resume_lines), current_edits_json, validation_warnings, model, created_at, sections_json)
         edits = run_generate(prompt, model)
         
         # validate response structure

--- a/src/loom_io/__init__.py
+++ b/src/loom_io/__init__.py
@@ -2,7 +2,14 @@
 # Package initialization and exports for Loom I/O operations
 
 # i/o utils for Loom
-from .documents import read_docx, write_docx, number_lines, read_text
+from .documents import (
+    read_docx, 
+    write_docx, 
+    number_lines, 
+    read_text,
+    read_docx_with_formatting,
+    apply_edits_to_docx
+)
 from .generics import write_json_safe, read_json_safe, ensure_parent, exit_with_error
 from .types import Lines
 
@@ -11,6 +18,8 @@ __all__ = [
     "write_docx", 
     "number_lines",
     "read_text",
+    "read_docx_with_formatting",
+    "apply_edits_to_docx",
     "write_json_safe",
     "read_json_safe", 
     "ensure_parent",

--- a/src/loom_io/documents.py
+++ b/src/loom_io/documents.py
@@ -1,25 +1,241 @@
 # src/loom_io/documents.py
-# Document I/O operations for reading and writing DOCX files and text processing
+# Document I/O operations for reading and writing DOCX files with formatting preservation
 
 from pathlib import Path
 from docx import Document
+from docx.text.paragraph import Paragraph
+from typing import Dict, Tuple, Any, List, Set
 from .types import Lines
 
-# read docx file & return text content
-def read_docx(path: Path) -> Lines:
+# read docx file & return both text content & document object
+def read_docx_with_formatting(path: Path) -> Tuple[Lines, Any, Dict[int, Paragraph]]:
     doc = Document(str(path))
     lines = {}
+    paragraph_map = {}
     line_number = 1
 
     for p in doc.paragraphs:
         text = p.text.strip()
         if text:
             lines[line_number] = text
+            paragraph_map[line_number] = p
             line_number += 1
 
+    return lines, doc, paragraph_map
+
+# read docx file & return text content (backward compatibility)
+def read_docx(path: Path) -> Lines:
+    lines, _, _ = read_docx_with_formatting(path)
     return lines
 
-# write text to docx file
+# apply edits to document with different preservation modes
+def apply_edits_to_docx(original_path: Path, new_lines: Lines, output_path: Path, 
+                        preserve_mode: str = "in_place") -> None:
+    # preserve_mode: "in_place" (better formatting preservation) or "rebuild" (faster)
+    if preserve_mode == "in_place":
+        _apply_edits_in_place(original_path, new_lines, output_path)
+    else:  # rebuild mode
+        _apply_edits_rebuild(original_path, new_lines, output_path)
+
+def _apply_edits_in_place(original_path: Path, new_lines: Lines, output_path: Path) -> None:
+    # edit document in-place to preserve all formatting, styles, headers, footers
+    
+    # reuse existing reader to build lines and paragraph map
+    lines, doc, paragraph_map = read_docx_with_formatting(original_path)
+    
+    # compute modifications / additions / deletions once
+    modifications, additions, deletions = _categorize_edits(lines, new_lines)
+    
+    # apply deletions from end to beginning
+    for line_num in sorted(deletions, reverse=True):
+        if line_num in paragraph_map:
+            para = paragraph_map[line_num]
+            p_element = para._element
+            p_element.getparent().remove(p_element)
+    
+    # apply modifications while preserving run-level formatting
+    for line_num, new_text in modifications.items():
+        if line_num in paragraph_map:
+            para = paragraph_map[line_num]
+            _set_paragraph_text_preserving_format(para, new_text)
+    
+    # group additions by insert position
+    additions_by_position: Dict[int | None, List[Tuple[int, str]]] = {}
+    for insert_after, line_num, text in additions:
+        if insert_after not in additions_by_position:
+            additions_by_position[insert_after] = []
+        additions_by_position[insert_after].append((line_num, text))
+    
+    # sort each group by line number
+    for position in additions_by_position:
+        additions_by_position[position].sort(key=lambda x: x[0])
+    
+    # insert new paragraphs
+    # sort only numeric positions (None is handled separately)
+    numeric_positions = sorted([p for p in additions_by_position.keys() if p is not None], reverse=True)
+    
+    # insert after specified paragraphs (from bottom up so indices remain valid)
+    for insert_after in numeric_positions:
+        reference_para = paragraph_map.get(insert_after)
+        if not reference_para:
+            continue
+        for line_num, text in reversed(additions_by_position[insert_after]):
+            new_para = _insert_paragraph_after(reference_para, text)
+            # copy style from reference paragraph
+            if reference_para.style:
+                new_para.style = reference_para.style
+    
+    # insert at beginning (reverse so final order is ascending)
+    if None in additions_by_position:
+        for line_num, text in reversed(additions_by_position[None]):
+            new_para = doc.add_paragraph(text)
+            doc.element.body.insert(0, new_para._element)
+    
+    # save modified document
+    doc.save(str(output_path))
+
+def _insert_paragraph_after(paragraph: Paragraph, text: str) -> Paragraph:
+    # insert new paragraph after given paragraph
+    new_p = paragraph._element.addnext(paragraph._element._new())
+    new_para = Paragraph(new_p, paragraph._parent)
+    new_para.text = text
+    return new_para
+
+def _copy_run_formatting(source_run, target_run) -> None:
+    # copy common run-level formatting if present
+    if not source_run:
+        return
+    if source_run.font:
+        if source_run.font.bold is not None:
+            target_run.font.bold = source_run.font.bold
+        if source_run.font.italic is not None:
+            target_run.font.italic = source_run.font.italic
+        if source_run.font.underline is not None:
+            target_run.font.underline = source_run.font.underline
+        if source_run.font.strike is not None:
+            target_run.font.strike = source_run.font.strike
+        if source_run.font.size is not None:
+            target_run.font.size = source_run.font.size
+        if source_run.font.name is not None:
+            target_run.font.name = source_run.font.name
+        if getattr(source_run.font, "color", None) and getattr(source_run.font.color, "rgb", None) is not None:
+            target_run.font.color.rgb = source_run.font.color.rgb
+        if getattr(source_run.font, "highlight_color", None) is not None:
+            target_run.font.highlight_color = source_run.font.highlight_color
+    if hasattr(source_run, "style") and source_run.style:
+        target_run.style = source_run.style
+
+def _set_paragraph_text_preserving_format(target_para: Paragraph, new_text: str, template_para: Paragraph | None = None) -> None:
+    # set new text while preserving first-run formatting from template
+    template = template_para if template_para is not None else target_para
+    template_run = template.runs[0] if template.runs else None
+    target_para.clear()
+    new_run = target_para.add_run(new_text)
+    if template_run:
+        _copy_run_formatting(template_run, new_run)
+
+def _categorize_edits(original_lines: Dict[int, str], new_lines: Lines):
+    # categorize edits into modifications, additions, deletions
+    modifications: Dict[int, str] = {}
+    additions: List[Tuple[int | None, int, str]] = []
+    deletions: Set[int] = set()
+    
+    original_set = set(original_lines.keys())
+    new_set = set(new_lines.keys())
+    
+    # lines to modify (exist in both but changed)
+    for line_num in sorted(new_set):
+        if line_num in original_set and new_lines[line_num] != original_lines[line_num]:
+            modifications[line_num] = new_lines[line_num]
+    
+    # lines to delete (exist in original but not in new)
+    for line_num in original_set:
+        if line_num not in new_set:
+            deletions.add(line_num)
+    
+    # lines to add (exist in new but not in original)
+    for line_num in sorted(new_set):
+        if line_num not in original_set:
+            insert_after = None
+            for existing_line in sorted(original_set):
+                if existing_line < line_num:
+                    insert_after = existing_line
+                else:
+                    break
+            additions.append((insert_after, line_num, new_lines[line_num]))
+    
+    return modifications, additions, deletions
+
+def _apply_edits_rebuild(original_path: Path, new_lines: Lines, output_path: Path) -> None:
+    # rebuild document from scratch (faster but may lose some formatting)
+    # read original document
+    lines, _, paragraph_map = read_docx_with_formatting(original_path)
+    
+    # sort line numbers for processing
+    sorted_line_nums = sorted(new_lines.keys())
+    max_original_line = max(lines.keys()) if lines else 0
+    
+    # track paragraphs to keep and their new content
+    paragraphs_to_process = []
+    
+    for line_num in sorted_line_nums:
+        new_text = new_lines[line_num]
+        
+        if line_num <= max_original_line and line_num in paragraph_map:
+            # existing paragraph, preserve formatting
+            para = paragraph_map[line_num]
+            paragraphs_to_process.append(('modify', para, new_text))
+        else:
+            # new paragraph not in original
+            paragraphs_to_process.append(('new', None, new_text))
+    
+    # create new document with edits
+    new_doc = Document()
+    
+    # note: document styles cannot be copied, will use defaults
+    
+    # process paragraphs in order
+    for action, original_para, new_text in paragraphs_to_process:
+        if action == 'modify' and original_para:
+            # preserve formatting from original
+            new_para = new_doc.add_paragraph()
+            
+            # copy paragraph-level formatting
+            if original_para.style:
+                new_para.style = original_para.style
+            if original_para.paragraph_format:
+                _copy_paragraph_format(original_para.paragraph_format, new_para.paragraph_format)
+            
+            # preserve character-level formatting via runs
+            if original_para.runs:
+                _set_paragraph_text_preserving_format(new_para, new_text, template_para=original_para)
+            else:
+                new_para.text = new_text
+        else:
+            # new paragraph without formatting reference
+            new_doc.add_paragraph(new_text)
+    
+    # save modified document
+    new_doc.save(str(output_path))
+
+def _copy_paragraph_format(source_format, target_format):
+    # best-effort copy of paragraph formatting properties
+    for prop in dir(source_format):
+        if prop.startswith('_'):
+            continue
+        try:
+            value = getattr(source_format, prop)
+        except Exception:
+            continue
+        if callable(value) or value is None:
+            continue
+        try:
+            setattr(target_format, prop, value)
+        except Exception:
+            # some properties might be read-only or unsupported
+            pass
+
+# write text to docx file (creates plain document)
 def write_docx(lines: Lines, output_path: Path) -> None:
     doc = Document()
     for line_num in sorted(lines.keys()):

--- a/src/loom_io/documents.py
+++ b/src/loom_io/documents.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 from docx import Document
 from docx.text.paragraph import Paragraph
+from docx.oxml import OxmlElement
 from typing import Dict, Tuple, Any, List, Set
 from .types import Lines
 
@@ -95,10 +96,13 @@ def _apply_edits_in_place(original_path: Path, new_lines: Lines, output_path: Pa
     doc.save(str(output_path))
 
 def _insert_paragraph_after(paragraph: Paragraph, text: str) -> Paragraph:
-    # insert new paragraph after given paragraph
-    new_p = paragraph._element.addnext(paragraph._element._new())
+    # insert new paragraph after given paragraph (python-docx safe)
+    new_p = OxmlElement("w:p")
+    # insert immediately after the reference paragraph
+    paragraph._p.addnext(new_p)
     new_para = Paragraph(new_p, paragraph._parent)
-    new_para.text = text
+    if text:
+        new_para.add_run(text)
     return new_para
 
 def _copy_run_formatting(source_run, target_run) -> None:


### PR DESCRIPTION
Refactors CLI argument handling to load settings once and apply defaults consistently across commands. Improves document editing with better validation, error handling, and python-docx–compatible paragraph insertion. Adds model and created_at metadata to prompts, and extracts shared core logic for edit generation and application. Enhances the tailor command to produce both edits and the final resume in a single step.